### PR TITLE
added archlinux support

### DIFF
--- a/tomcat/manager.sls
+++ b/tomcat/manager.sls
@@ -1,15 +1,21 @@
+include: 
+  - tomcat
 {% if grains.os != 'FreeBSD' %}
 {% from "tomcat/map.jinja" import tomcat with context %}
+
+# on archlinux tomcat manager is already in tomcat package
+{% if grains.os != 'Arch' %}
 
 {{ tomcat.manager }}:
   pkg:
     - installed
+{% endif %}
 
 /etc/{{ tomcat.name }}{{ tomcat.version }}/tomcat-users.xml:
     file.managed:
         - source: salt://tomcat/files/tomcat-users.xml
         - user: root
-        - group: tomcat7
+        - group: {{ tomcat.name }}{{ tomcat.version }}
         - mode: 640
         - template: jinja
         - defaults:

--- a/tomcat/map.jinja
+++ b/tomcat/map.jinja
@@ -33,4 +33,10 @@
         'service': 'tomcat',
         'native': 'tomcat-native',
     },
+    'Arch': {
+        'name': 'tomcat',
+        'version': 8,
+        'service': 'tomcat',
+        'native': 'tomcat-native'
+    },
 }, merge=salt['pillar.get']('tomcat:lookup')) %}

--- a/tomcat/package.sls
+++ b/tomcat/package.sls
@@ -7,7 +7,14 @@
     - running
     - watch:
       - pkg: {{ tomcat.name }}{{ tomcat.version }}
-      - file.append: tomcat_conf
+      - file: tomcat_conf
+
+{% if grains.os == 'Arch' %}
+tomcat_env:
+  file.managed:
+    - name: /etc/conf.d/{{ tomcat.name }}{{ tomcat.version }}
+{% endif %}
+
 tomcat_conf:
   file.append:
     {% if grains.os == 'FreeBSD' %}
@@ -15,6 +22,22 @@ tomcat_conf:
     - text:
       - tomcat{{ tomcat.version }}_java_home="{{ salt['pillar.get']('java:home', '/usr') }}"
       - tomcat{{ tomcat.version }}_java_opts="-Djava.awt.headless=true -Xmx{{ salt['pillar.get']('java:Xmx', '3G') }} -XX:MaxPermSize={{ salt['pillar.get']('java:MaxPermSize', '256m') }}"
+    {% elif grains.os == 'Arch' %}
+    - name: /etc/conf.d/{{ tomcat.name }}{{ tomcat.version }}
+    - text: 
+      - JAVA_HOME={{ salt['pillar.get']('java:home', '/usr/lib/jvm/java-7-openjdk') }}
+      - JAVA_OPTS="-Djava.awt.headless=true -Xmx{{ salt['pillar.get']('java:Xmx', '3G') }} -XX:MaxPermSize={{ salt['pillar.get']('java:MaxPermSize', '256m') }}"
+      {% if salt['pillar.get']('java:UseConcMarkSweepGC') %}
+      - JAVA_OPTS="$JAVA_OPTS {{ salt['pillar.get']('java:UseConcMarkSweepGC') }}"
+      {% endif %}
+      {% if salt['pillar.get']('java:CMSIncrementalMode') %}
+      - JAVA_OPTS="$JAVA_OPTS {{ salt['pillar.get']('java:CMSIncrementalMode') }}"
+      {% endif %}
+      {% if salt['pillar.get']('tomcat:security') %}
+      - TOMCAT{{ tomcat.version }}_SECURITY={{ salt['pillar.get']('tomcat:security', 'no') }}
+      {% endif %}
+    - require:
+      - file: tomcat_env
     {% else %}
     - name: /etc/default/tomcat{{ tomcat.version }}
     - text:


### PR DESCRIPTION
On package state it needed some extra archlinux magic.
  Archlinux tomcat package supports environment file at /etc/conf.d/tomcat(version)
  but file.append doesn't create a file if it doesn't exists.

On the manager state archlinux already ships with manager only tomcat-users.xml is empty.
