### PR TITLE
Prevent clashes in SLS.ID between tomcat.package and tomcat.ssl

### DIFF
--- a/tomcat/ssl.sls
+++ b/tomcat/ssl.sls
@@ -29,8 +29,9 @@
             keystorePass: {{ salt['pillar.get']('tomcat:connector:keystorePass', '') }}
             {% endif %}
 
-{{ tomcat.service }}:
+{{ tomcat.service }}-ssl:
   service:
+    - name: {{ tomcat.service }}
     - running
     - watch:
       - file: /etc/{{ tomcat.name }}{{ tomcat.version }}/server.xml


### PR DESCRIPTION
Prevents:

local:
##     Data failed to compile:

```
Detected conflicting IDs, SLS IDs need to be globally unique.
The conflicting ID is "tomcat" and is found in SLS "base:tomcat.package" and SLS "base:tomcat.ssl"
```
