### PR TITLE
Update RedHat native package name

### DIFF
--- a/tomcat/map.jinja
+++ b/tomcat/map.jinja
@@ -19,7 +19,7 @@
         'name': 'tomcat',
         'version': version,
         'service': service,
-        'native': 'libtcnative-1',
+        'native': 'tomcat-native',
         'manager': 'tomcat-admin-webapps',
     },
     'openSUSE': {


### PR DESCRIPTION
Resolves issue #21.

Tested on Red Hat Enterprise Linux Server release 6.5 (Santiago)
tomcat-native.x86_64 : Tomcat native library
