### PR TITLE
Allow specifiying multiple connectors in server.xml

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -72,7 +72,6 @@ provisioner:
               reloadable: "true"
               debug: 0        
 
-
 suites:
   - name: tomcat_install
     provisioner:
@@ -81,7 +80,6 @@ suites:
           '*':
             - tomcat
             - tomcat.manager
-            - tomcat.native
   - name: tomcat_config
     provisioner:
       state_top:

--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,8 @@ Linux distros (Debian, RedHat, Arch) and their derivatives.
 ``tomcat.native``
 -----------------
 
-Installs Apache Portable Runtime for Tomcat.
+Installs Apache Portable Runtime for Tomcat. Depends on ``tomcat.config``
+to manage the configuration.
 
 ``tomcat.manager``
 -----------------

--- a/pillar.example
+++ b/pillar.example
@@ -33,24 +33,25 @@ tomcat:
       soft: 64000
       hard: 64000
     connector:
-      port: 8443
-      protocol: 'org.apache.coyote.http11.Http11Protocol'
-      connectionTimeout: 20000
-      URIEncoding: 'UTF-8'
-      redirectPort: 8443
-      maxHttpHeaderSize: 8192
-      maxThreads: 150
-      minSpareThreads: 25
-      enableLookups: 'false'
-      disableUploadTimeout: 'true'
-      acceptCount: 100
-      scheme: https
-      secure: 'true'
-      SSLEnabled: 'true'
-      clientAuth: 'false'
-      sslProtocol: TLS
-      keystoreFile: '/path/to/keystoreFile'
-      keystorePass: 'somerandomtext'
+      example_connector:
+        port: 8443
+        protocol: 'org.apache.coyote.http11.Http11Protocol'
+        connectionTimeout: 20000
+        URIEncoding: 'UTF-8'
+        redirectPort: 8443
+        maxHttpHeaderSize: 8192
+        maxThreads: 150
+        minSpareThreads: 25
+        enableLookups: 'false'
+        disableUploadTimeout: 'true'
+        acceptCount: 100
+        scheme: https
+        secure: 'true'
+        SSLEnabled: 'true'
+        clientAuth: 'false'
+        sslProtocol: TLS
+        keystoreFile: '/path/to/keystoreFile'
+        keystorePass: 'somerandomtext'
     sites:
         example.com: # must be unique; used as an ID declaration in Salt; also used in the  template as {{ host_name }} is name is not declared
           name: some_string # to use as "Host name=" in server.xml definitions. If not declared, ID declaration will be used

--- a/test/integration/tomcat_config/serverspec/tomcat_config_spec.rb
+++ b/test/integration/tomcat_config/serverspec/tomcat_config_spec.rb
@@ -4,6 +4,7 @@ describe 'tomcat/config.sls' do
   case os[:family]
   when 'debian'
     ver = '8'
+    pkgs_installed = %w(libtcnative-1)
     main_config = '/etc/default/tomcat8'
     server_config = '/etc/tomcat8/server.xml'
     web_config = '/etc/tomcat8/web.xml'
@@ -18,6 +19,7 @@ describe 'tomcat/config.sls' do
     limits_file = '/etc/security/limits.d/tomcat8.conf'
   when 'redhat'
     ver = '8'
+    pkgs_installed = %w(tomcat-native)
     main_config = '/etc/sysconfig/tomcat'
     server_config = '/etc/tomcat8/server.xml'
     web_config = '/etc/tomcat8/web.xml'
@@ -32,6 +34,7 @@ describe 'tomcat/config.sls' do
     limits_file = '/etc/security/limits.d/tomcat7.conf'
   when 'arch'
     ver = '8'
+    pkgs_installed = %w(tomcat-native)
     main_config = '/usr/lib/systemd/system/tomcat8.service'
     server_config = '/etc/tomcat8/server.xml'
     web_config = '/etc/tomcat8/web.xml'
@@ -44,6 +47,12 @@ describe 'tomcat/config.sls' do
     group = 'tomcat8'
     java_home = '/usr/lib/jvm/default-runtime'
     limits_file = '/etc/security/limits.conf'
+  end
+
+  pkgs_installed.each do |p|
+    describe package(p) do
+      it { should be_installed }
+    end
   end
 
   describe service(service) do

--- a/test/integration/tomcat_install/serverspec/install_spec.rb
+++ b/test/integration/tomcat_install/serverspec/install_spec.rb
@@ -3,17 +3,17 @@ require_relative '../../../kitchen/data/spec_helper'
 describe 'tomcat/init.sls' do
   case os[:family]
   when 'debian'
-    pkgs_installed = %w(tomcat8 haveged tomcat8-admin libtcnative-1)
+    pkgs_installed = %w(tomcat8 haveged tomcat8-admin)
     pkgs_not_installed = []
     main_config = '/etc/default/tomcat8'
     service = 'tomcat8'
   when 'redhat'
-    pkgs_installed = %w(tomcat tomcat-admin-webapps tomcat-native)
+    pkgs_installed = %w(tomcat tomcat-admin-webapps)
     pkgs_not_installed = %w(haveged)
     main_config = '/etc/sysconfig/tomcat'
     service = 'tomcat'
   when 'arch'
-    pkgs_installed = %w(tomcat8 haveged tomcat-native)
+    pkgs_installed = %w(tomcat8 haveged)
     pkgs_not_installed = []
     main_config = '/usr/lib/systemd/system/tomcat8.service'
     service = 'tomcat8'

--- a/tomcat/config.sls
+++ b/tomcat/config.sls
@@ -30,7 +30,7 @@ tomcat_conf:
 100_server_xml:
   file.accumulated:
     - filename: {{ tomcat.conf_dir }}/server.xml
-    - text: {{ tomcat.connector }}
+    - text: {{ tomcat.connectors }}
     - require_in:
       - file: server_xml
 

--- a/tomcat/defaults.yaml
+++ b/tomcat/defaults.yaml
@@ -19,23 +19,6 @@ tomcat:
     - 'XX:+UseConcMarkSweepGC'
   limit_soft: 64000
   limit_hard: 64000
-  connector:
-    SSLEnabled: false
-    port: 8080
-    protocol: 'HTTP/1.1'
-    connectionTimeout: 20000
-    URIEncoding: 'UTF-8'
-    redirectPort: 8443
-    maxHttpHeaderSize: 8192
-    maxThreads: 150
-    minSpareThreads: 25
-    enableLookups: false
-    disableUploadTimeout: true
-    acceptCount: 100
-    scheme: http
-    secure: true
-    clientAuth: false
-    sslProtocol: TLSv1.2
-    keystoreFile: ''
-    keystorePass: ''
+  connectors: {}
+  sites: {}
 

--- a/tomcat/files/server.xml
+++ b/tomcat/files/server.xml
@@ -1,3 +1,5 @@
+{% set connectors = accumulator['100_server_xml'][0] if '100_server_xml' in accumulator else {} -%}
+{% set sites = accumulator['300_server_xml'][0] if '300_server_xml' in accumulator else {} -%}
 <?xml version='1.0' encoding='utf-8'?>
 <!--
 
@@ -67,13 +69,16 @@
        Documentation at /docs/config/service.html
    -->
   <Service name="Catalina">
-    {% if '100_server_xml' in accumulator %}
+    {% if connectors -%}
+    {% for id, params in connectors.iteritems() -%}
     <Connector
-    {% for id, param in accumulator['100_server_xml'][0].iteritems() %}
-               {{ id }}="{{ param }}"
-    {% endfor %}
+    {% for k, v in params.iteritems() %}
+               {{ k }}="{{ v }}"
+    {%- endfor %}
     />
+    {% endfor %}
     {% else %}
+    <!-- Setting a default connector, as no connectors were defined in the formula -->
     <!-- A "Connector" represents an endpoint by which requests are received
          and responses are returned. Documentation at :
          Java HTTP Connector: /docs/config/http.html (blocking & non-blocking)
@@ -100,8 +105,8 @@
                resourceName="UserDatabase"/>
       </Realm>
       
-      {% if '300_server_xml' in accumulator %}
-      {% for id, site in accumulator['300_server_xml'][0].iteritems()  %}
+      {% if sites %}
+      {% for id, site in sites.iteritems()  %}
       {%- set host_name = site.name if site.name is defined else id %}
       <Host name="{{ host_name }}"
             appBase="{{ site.appBase }}"
@@ -124,6 +129,7 @@
       </Host>
       {% endfor %}
       {% else %}
+        <!-- Setting a default site, as no sites were defined in the formula -->
         <Host name="localhost"  appBase="webapps" unpackWARs="true" autoDeploy="true">
         <Valve className="org.apache.catalina.valves.AccessLogValve" directory="logs"
                prefix="localhost_access_log." suffix=".txt"


### PR DESCRIPTION
`connectors`, in the `server.xml` file might be specified multiple times. The way it was declared, was allowing only one specification of it. Modified it to be a dict following the same logic as `sites`. This change is backward incompatible, as requires to reformat the `connector` -> `connectors` entry in the pillar.

Modified the defaults to be empty, so the default entries in `server.xml` are used (which, ideally, should be the same as in a default installation). Otherwise, those never were used.

Fixed tests and README, to match these new changes.