### PR TITLE
Fix valves in server.xml template.

### DIFF
--- a/tomcat/files/server.xml
+++ b/tomcat/files/server.xml
@@ -159,12 +159,12 @@
             {% endif %}
 
             {%- if site.valves is defined %}
-						{%- for valve in site.valves  %}
+	    {%- for valve in site.valves  %}
               <Valve
               {%- for k, v in valve.iteritems() %}
                 {{ k }}="{{ v }}"
               {%- endfor %} />
-						{%- endfor %}
+	    {%- endfor %}
             {% endif %}
       </Host>
       {% endfor %}

--- a/tomcat/files/server.xml
+++ b/tomcat/files/server.xml
@@ -157,12 +157,15 @@
             {%- if site.alias is defined %}
             <Alias>{{ site.alias }}</Alias>
             {% endif %}
-            {%- for valve in site.valves  %}
+
+            {%- if site.valves is defined %}
+						{%- for valve in site.valves  %}
               <Valve
               {%- for k, v in valve.iteritems() %}
                 {{ k }}="{{ v }}"
               {%- endfor %} />
-            {%- endfor %}
+						{%- endfor %}
+            {% endif %}
       </Host>
       {% endfor %}
       {% else %}


### PR DESCRIPTION
With current code, when you don't define any valve for a site you'll get an error. 
This simple fix allows you to define a site without any valve. 