### PR TITLE
connector -> connectors fix for pillar.example

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -37,7 +37,7 @@ tomcat:
     limit:
       soft: 64000
       hard: 64000
-    connector:
+    connectors:
       example_connector:
         port: 8443
         protocol: 'org.apache.coyote.http11.Http11Protocol'


### PR DESCRIPTION
PR #42 reformatted `connector` -> `connectors` in the pillar, but the `pillar.example` file was not updated to reflect this change.  This fixes it.