### PR TITLE
Fix tomcat.native symlink on Trusty

### DIFF
--- a/tomcat/native.sls
+++ b/tomcat/native.sls
@@ -14,7 +14,7 @@ include:
       - file: server_xml
 
 {% if grains.get('oscodename') == 'trusty' %}
-/usr/lib/{{grains['cpuarch']}}-linux-gnu/libtcnative-1.so:
+/usr/lib/libtcnative-1.so:
   file.symlink:
-    - target: /usr/lib/libtcnative-1.so
+    - target: /usr/lib/{{grains['cpuarch']}}-linux-gnu/libtcnative-1.so
 {% endif %}


### PR DESCRIPTION
This fixes #57.

    # ls -l /usr/lib/x86_64-linux-gnu/libtcnative-1.so.0
    lrwxrwxrwx 1 root root 23 Dec 25  2013 /usr/lib/x86_64-linux-gnu/libtcnative-1.so.0 -> libtcnative-1.so.0.1.29
    # ls -l /usr/lib/libtcnative-1.so
    lrwxrwxrwx 1 root root 42 Apr 11 10:39 /usr/lib/libtcnative-1.so -> /usr/lib/x86_64-linux-gnu/libtcnative-1.so