### PR TITLE
Classpath Munging Change

### DIFF
--- a/tomcat/files/tomcat-default-CentOS.template
+++ b/tomcat/files/tomcat-default-CentOS.template
@@ -46,6 +46,14 @@ CATALINA_PID="{{ tomcat.catalina_pid }}"
 #JAVA_OPTS="-Xminf0.1 -Xmaxf0.3"
 JAVA_OPTS="{{ tomcat_java_opts }}"
 
+{% if tommcat.java_classpath is defined -%}
+CLASSPATH="{{ tomcat.java_classpath }}"
+{% else -%}
+#if CLASSPATH is defined in JAVA_OPTS it may no longer munge with the default CLASSPATH
+#replace and customize if necessary
+#CLASSPATH=/usr/share/tomcat/bin/bootstrap.jar:/usr/share/tomcat/bin/tomcat-juli.jar:/usr/share/java/commons-daemon.jar
+{%- endif %}
+
 # Use JAVA_OPTS to set java.library.path for libtcnative.so
 #JAVA_OPTS="-Djava.library.path=/usr/lib64"
 

--- a/tomcat/files/tomcat-default-CentOS.template
+++ b/tomcat/files/tomcat-default-CentOS.template
@@ -46,7 +46,7 @@ CATALINA_PID="{{ tomcat.catalina_pid }}"
 #JAVA_OPTS="-Xminf0.1 -Xmaxf0.3"
 JAVA_OPTS="{{ tomcat_java_opts }}"
 
-{% if tommcat.java_classpath is defined -%}
+{% if tomcat.java_classpath is defined -%}
 CLASSPATH="{{ tomcat.java_classpath }}"
 {% else -%}
 #if CLASSPATH is defined in JAVA_OPTS it may no longer munge with the default CLASSPATH


### PR DESCRIPTION
RHEL7 and Tomcat7's preamble seems to have changed CLASSPATH munging from RHEL5+6, so you can no longer put the classpath inside the environmental variable JAVA_OPTS
I figured out how to fix my issue, and here is how to fix it for others in the salt community.
Addresses this issue:
https://github.com/saltstack-formulas/tomcat-formula/issues/59