### PR TITLE
Learnings from #63 (host_name, id, etc)

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -1,6 +1,6 @@
 ## Required variables for functional pillar.example ##
 {% set host_name = salt['grains.get']('hostname') %}
-{% set id        = salt['grains.get']('get_hostname_id') %}
+{% set id        = salt['grains.get']('get_server_id') %}
 {% set inetdomain1 = 'example.com' %}
 {% set inetdomain2 = 'example.net' %}
 

--- a/pillar.example
+++ b/pillar.example
@@ -178,3 +178,23 @@ tomcat:
           name: linkToGlobalResource
           global: simpleValue
           type: java.lang.Integer
+    other_contexts:
+      'path#to#context':   # will be available at '/path/to/context'
+        params:            # parameters to the context itself.
+          docBase: /path/to/webapp
+          debug: 1
+          reloadable: 'true'
+          crossContext: 'true'
+        elements:          # elements take the same form as the default 'context' section above.
+          Resource:
+            jdbc:
+              name: jdbc/__postgres
+              auth: Container
+              type: javax.sql.DataSource
+              driverClassName: org.postgresql.Driver
+              url: jdbc:postgresql://db.server/dbname
+              user: dbuser
+              password: aycaramba!
+              maxActive: 20
+              maxIdle: 10
+              maxWait: -1

--- a/pillar.example
+++ b/pillar.example
@@ -1,3 +1,7 @@
+{% set host_name = salt['grains.get']('hostname') %}
+{% set id        = salt['grains.get']('get_hostname_id') %}
+host_name: {{ host_name }}
+id: {{ id }}
 tomcat:
     # The Tomcat version can be overridden like so.
     # ver: 7
@@ -58,8 +62,8 @@ tomcat:
         keystoreFile: '/path/to/keystoreFile'
         keystorePass: 'somerandomtext'
     sites:
-        example.com: # must be unique; used as an ID declaration in Salt; also used in the  template as {{ host_name }} is name is not declared
-          name: some_string # to use as "Host name=" in server.xml definitions. If not declared, ID declaration will be used
+        example.com: # must be unique; used as an ID declaration in Salt; also used in the  template as {{ host_name }} if name is not declared
+          name: {{ host_name }} # to use as "Host name=" in server.xml definitions. If not declared, ID declaration will be used
           appBase: ../webapps/myapp
           path: ''
           docBase: '/var/lib/tomcat7/webapps/myapp'

--- a/pillar.example
+++ b/pillar.example
@@ -1,7 +1,9 @@
+## Required variables for functional pillar.example ##
 {% set host_name = salt['grains.get']('hostname') %}
 {% set id        = salt['grains.get']('get_hostname_id') %}
-host_name: {{ host_name }}
-id: {{ id }}
+{% set inetdomain1 = 'example.com' %}
+{% set inetdomain2 = 'example.net' %}
+
 tomcat:
     # The Tomcat version can be overridden like so.
     # ver: 7
@@ -62,7 +64,7 @@ tomcat:
         keystoreFile: '/path/to/keystoreFile'
         keystorePass: 'somerandomtext'
     sites:
-        example.com: # must be unique; used as an ID declaration in Salt; also used in the  template as {{ host_name }} if name is not declared
+        {{ inetdomain1 }}: # must be unique; used as an ID declaration in Salt; also used in the  template as {{ host_name }} if name is not declared
           name: {{ host_name }} # to use as "Host name=" in server.xml definitions. If not declared, ID declaration will be used
           appBase: ../webapps/myapp
           path: ''
@@ -74,7 +76,7 @@ tomcat:
             deployXML: "false"
           reloadable: "true"
           debug: 0
-        example.net:
+        {{ inetdomain2 }}:
           appBase: ../webapps/myapp2
           path: ''
           docBase: '/var/lib/tomcat7/webapps/myapp2'

--- a/tomcat/context.sls
+++ b/tomcat/context.sls
@@ -3,6 +3,7 @@
 include:
   - tomcat
 
+{% if tomcat.get('context', False) %}
 {{ tomcat.conf_dir }}/context.xml:
   file.managed:
     - source: salt://tomcat/files/context.xml
@@ -11,11 +12,31 @@ include:
     - mode: '640'
     - template: jinja
     - defaults:
-      tomcat: {{ tomcat }}
+      context_elements: {{ tomcat.get('context', {}) }}
+      context_params: {}
     - require:
       - pkg: tomcat
     - require_in:
       - service: tomcat
     - watch_in:
       - service: tomcat
+{% endif %}
 
+{% for label, data in tomcat.get('other_contexts', {}).items() %}
+{{ tomcat.conf_dir }}/Catalina/localhost/{{ data.get('context', label) }}.xml:
+  file.managed:
+    - source: salt://tomcat/files/context.xml
+    - user: root
+    - group: {{ tomcat.group }}
+    - mode: '640'
+    - template: jinja
+    - defaults:
+      context_elements: {{ data.get('elements', {}) }}
+      context_params: {{ data.get('params', {}) }}
+    - require:
+      - pkg: tomcat
+    - require_in:
+      - service: tomcat
+    - watch_in:
+      - service: tomcat
+{% endfor %}

--- a/tomcat/files/context.xml
+++ b/tomcat/files/context.xml
@@ -1,5 +1,3 @@
-{% from "tomcat/map.jinja" import tomcat with context -%}
-{% set context_elements = tomcat.context if tomcat.context else {} -%}
 <?xml version='1.0' encoding='utf-8'?>
 <!--
 
@@ -27,35 +25,35 @@
   limitations under the License.
 -->
 <!-- The contents of this file will be loaded for each web application -->
-<Context>
+<Context
+{%- for k, v in context_params.items() %}
+  {{ k }}="{{ v }}"
+{%- endfor %}
+  >
 
     <!-- Default set of monitored resources. If one of these changes, the    -->
     <!-- web application will be reloaded.                                   -->
     <WatchedResource>WEB-INF/web.xml</WatchedResource>
     <WatchedResource>${catalina.base}/conf/web.xml</WatchedResource>
 
-    {% if context_elements -%}
-    {% for element_type, elements in context_elements.iteritems() -%}
-    {% for element, params in elements.iteritems() -%}
+{% for element_type, elements in context_elements.iteritems() -%}
+  {% for element, params in elements.iteritems() -%}
     <{{ element_type }}
             {%- for k, v in params.iteritems() %}
             {{ k }}="{{ v }}"
             {%- endfor %}
     />
-    {% endfor -%}
-    {% endfor -%}
-    {% else %}
+  {% endfor -%}
+{% endfor -%}
 
     <!-- Uncomment this to disable session persistence across Tomcat restarts -->
     <!--
     <Manager pathname="" />
     -->
-  
+
     <!-- Uncomment this to enable Comet connection tacking (provides events
          on session expiration as well as webapp lifecycle) -->
     <!--
     <Valve className="org.apache.catalina.valves.CometConnectionManagerValve" />
     -->
-    {% endif %}
 </Context>
-


### PR DESCRIPTION
This PR uses grains to define hostname and hostname_id values - otherwise undocumented and causing obscure messages when executing formula.  Tested: Fedora/Ubuntu/SUSE Fixes #62 #63 