### PR TITLE
Resolve issue 62 (osmap.yaml) and 63 (pillar.example vars)

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -1,8 +1,6 @@
-## Required variables for functional pillar.example ##
-{% set host_name = salt['grains.get']('hostname') %}
-{% set id        = salt['grains.get']('get_server_id') %}
-{% set inetdomain1 = 'example.com' %}
-{% set inetdomain2 = 'example.net' %}
+# Required for functional pillar.example #
+{% set host_name   = salt['grains.get']('hostname') %}
+{% set id = 'example' %}
 
 tomcat:
     # The Tomcat version can be overridden like so.
@@ -64,23 +62,23 @@ tomcat:
         keystoreFile: '/path/to/keystoreFile'
         keystorePass: 'somerandomtext'
     sites:
-        {{ inetdomain1 }}: # must be unique; used as an ID declaration in Salt; also used in the  template as {{ host_name }} if name is not declared
+        {{ id }}.com: # must be unique; used as an ID declaration in Salt; also used in the  template as {{ host_name }} if name is not declared
           name: {{ host_name }} # to use as "Host name=" in server.xml definitions. If not declared, ID declaration will be used
           appBase: ../webapps/myapp
           path: ''
           docBase: '/var/lib/tomcat7/webapps/myapp'
-          alias: {{ id }}
+          alias: www.{{ id }}.com
           host_parameters:
             unpackWARs: "true"
             autoDeploy: "true"
             deployXML: "false"
           reloadable: "true"
           debug: 0
-        {{ inetdomain2 }}:
+        {{ id }}.net:
           appBase: ../webapps/myapp2
           path: ''
           docBase: '/var/lib/tomcat7/webapps/myapp2'
-          alias: {{ id }}
+          alias: www.{{ id }}.net
           unpackWARs: "true"
           autoDeploy: "true"
           reloadable: "true"

--- a/pillar.example
+++ b/pillar.example
@@ -1,3 +1,9 @@
+## Required variables for functional pillar.example ##
+{% set host_name = salt['grains.get']('hostname') %}
+{% set id        = salt['grains.get']('get_server_id') %}
+{% set inetdomain1 = 'example.com' %}
+{% set inetdomain2 = 'example.net' %}
+
 tomcat:
     # The Tomcat version can be overridden like so.
     # ver: 7
@@ -58,8 +64,8 @@ tomcat:
         keystoreFile: '/path/to/keystoreFile'
         keystorePass: 'somerandomtext'
     sites:
-        example.com: # must be unique; used as an ID declaration in Salt; also used in the  template as {{ host_name }} is name is not declared
-          name: some_string # to use as "Host name=" in server.xml definitions. If not declared, ID declaration will be used
+        {{ inetdomain1 }}: # must be unique; used as an ID declaration in Salt; also used in the  template as {{ host_name }} if name is not declared
+          name: {{ host_name }} # to use as "Host name=" in server.xml definitions. If not declared, ID declaration will be used
           appBase: ../webapps/myapp
           path: ''
           docBase: '/var/lib/tomcat7/webapps/myapp'
@@ -70,7 +76,7 @@ tomcat:
             deployXML: "false"
           reloadable: "true"
           debug: 0
-        example.net:
+        {{ inetdomain2 }}:
           appBase: ../webapps/myapp2
           path: ''
           docBase: '/var/lib/tomcat7/webapps/myapp2'

--- a/tomcat/osmap.yaml
+++ b/tomcat/osmap.yaml
@@ -22,7 +22,7 @@ CentOS:
   native_pkg: tomcat-native
   manager_pkg: tomcat-admin-webapps
   main_config_template: salt://tomcat/files/tomcat-default-CentOS.template
-openSUSE:
+Suse:
   native_pkg: libtcnative-1-0
   manager_pkg: tomcat-admin-webapps
   main_config_template: salt://tomcat/files/tomcat-default-CentOS.template

--- a/tomcat/osmap.yaml
+++ b/tomcat/osmap.yaml
@@ -22,6 +22,10 @@ CentOS:
   native_pkg: tomcat-native
   manager_pkg: tomcat-admin-webapps
   main_config_template: salt://tomcat/files/tomcat-default-CentOS.template
+OpenSUSE:
+  native_pkg: libtcnative-1-0
+  manager_pkg: tomcat-admin-webapps
+  main_config_template: salt://tomcat/files/tomcat-default-CentOS.template
 Suse:
   native_pkg: libtcnative-1-0
   manager_pkg: tomcat-admin-webapps

--- a/tomcat/osmap.yaml
+++ b/tomcat/osmap.yaml
@@ -22,7 +22,7 @@ CentOS:
   native_pkg: tomcat-native
   manager_pkg: tomcat-admin-webapps
   main_config_template: salt://tomcat/files/tomcat-default-CentOS.template
-OpenSUSE:
+openSUSE:
   native_pkg: libtcnative-1-0
   manager_pkg: tomcat-admin-webapps
   main_config_template: salt://tomcat/files/tomcat-default-CentOS.template


### PR DESCRIPTION
This PR replaces #64 due to rebase, etc.

The pillar.example is updated to defined hostname and hostname_id values from grains and also set fix the undefined {{ id }} reference.  example.com and example.net are converted to variables.
Fixes #64 

This osmap.yaml is updated to support OpenSUSE:
Fixes #62 

Installation successfully tested on OpenSUSE LEAP (4.2) server and Ubuntu 17.04