### PR TITLE
Fix tomcat.manager state for Archlinux family to resolve #67

### DIFF
--- a/tomcat/manager.sls
+++ b/tomcat/manager.sls
@@ -5,8 +5,8 @@ include:
 
 {% if grains.os != 'FreeBSD' %}
 
-# on archlinux tomcat manager is already in tomcat package
-{% if grains.os != 'Arch' %}
+# on archlinux family tomcat manager is already in tomcat package
+{% if grains.os_family != 'Arch' %}
 {{ tomcat.manager_pkg }}:
   pkg.installed:
     - require:


### PR DESCRIPTION
This PR resolves #67.  Archlinux derivatives use pacman and archlinux packaging so tomcat.manager state must check `grains.os_family == Arch` because 'grains.os == Arch' is too specific.   

Test successfully on Manjaro: [tomcat_manjaro_testresult.log.txt](https://github.com/saltstack-formulas/tomcat-formula/files/1347216/tomcat_manjaro_testresult.log.txt)
