### PR TITLE
Consolidate 'defaults' in Formula: Fixes and improvements

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -1,6 +1,5 @@
-# Required for functional pillar.example #
 {% set host_name   = salt['grains.get']('hostname') %}
-{% set id = 'example' %}
+{% set id          = ['example.com','example.net'] %}
 
 tomcat:
     # The Tomcat version can be overridden like so.
@@ -20,23 +19,14 @@ tomcat:
       - 'XX:MaxPermSize=256m'
       - 'XX:+UseConcMarkSweepGC'
       - 'XX:+CMSIncrementalMode'
-      - 'Dlog4j.configuration=file:/path/to/log4j.properties'
-      - 'Dlogback.configurationFile=/path/to/logback.xml'
+    # Change paths to correct locations
+      - 'Dlog4j.configuration=file:/tmp/log4j.properties'
+      - 'Dlogback.configurationFile=/tmp/logback.xml'
     jsp_compiler: javac
     logfile_days: 14
     logfile_compress: 1
-    jvm_tmp: /tmp/tomcat
     authbind: no
     expires_when: '2 weeks'
-    with_haveged: true
-    haveged_enabled: true
-    cluster:
-      simple: true
-
-    catalina_base: /usr/share/tomcat
-    catalina_home: /usr/share/tomcat
-    catalina_tmpdir: /var/cache/tomcat/temp
-    catalina_pid: /var/run/tomcat.pid
 
     limit:
       soft: 64000
@@ -56,31 +46,33 @@ tomcat:
         acceptCount: 100
         scheme: https
         secure: 'true'
-        SSLEnabled: 'true'
         clientAuth: 'false'
         sslProtocol: TLS
+        SSLEnabled: 'false'
+        #Change to realpath before setting "SSLEnabled: 'true'"
         keystoreFile: '/path/to/keystoreFile'
         keystorePass: 'somerandomtext'
     sites:
-        {{ id }}.com: # must be unique; used as an ID declaration in Salt; also used in the  template as {{ host_name }} if name is not declared
+        {{ id[0] }}: # must be unique; used as an ID declaration in Salt; also used in the  template as {{ host_name }} if name is not declared
           name: {{ host_name }} # to use as "Host name=" in server.xml definitions. If not declared, ID declaration will be used
           appBase: ../webapps/myapp
           path: ''
-          docBase: '/var/lib/tomcat7/webapps/myapp'
-          alias: www.{{ id }}.com
+          docBase: ../webapps/myapp
+          alias: www.{{ id[0] }}
           host_parameters:
             unpackWARs: "true"
             autoDeploy: "true"
             deployXML: "false"
           reloadable: "true"
           debug: 0
-        {{ id }}.net:
+        {{ id[1] }}:
           appBase: ../webapps/myapp2
           path: ''
-          docBase: '/var/lib/tomcat7/webapps/myapp2'
-          alias: www.{{ id }}.net
-          unpackWARs: "true"
-          autoDeploy: "true"
+          docBase: ../webapps/myapp2
+          alias: www.{{ id[1] }}
+          host_parameters:
+            unpackWARs: "true"
+            autoDeploy: "true"
           reloadable: "true"
           debug: 0
           valves:
@@ -183,7 +175,7 @@ tomcat:
           global: simpleValue
           type: java.lang.Integer
     other_contexts:
-      'path#to#context':   # will be available at '/path/to/context'
+      'other-contexts':   # will be available at 'tomcat.conf_dir/Catalina/localhost/context'
         params:            # parameters to the context itself.
           docBase: /path/to/webapp
           debug: 1

--- a/tomcat/defaults.yaml
+++ b/tomcat/defaults.yaml
@@ -23,3 +23,17 @@ tomcat:
   connectors: {}
   sites: {}
   resources: {}
+
+  #Relocated from pillar.example
+  id: ['example.com','example.net']
+  jvm_tmp: /tmp/tomcat
+  with_haveged: true
+  haveged_enabled: true
+  cluster:
+    simple: true
+
+  catalina_base: /usr/share/tomcat
+  catalina_home: /usr/share/tomcat
+  catalina_pid: /var/run/tomcat.pid
+  #Used by generic 'tomcat-default-CentOS.template'
+  catalina_tmpdir: /var/cache/tomcat/temp

--- a/tomcat/osmap.yaml
+++ b/tomcat/osmap.yaml
@@ -49,3 +49,31 @@ Arch:
   catalina_pid: /var/run/tomcat8.pid
   catalina_base: /usr/share/tomcat8
   catalina_home: /usr/share/tomcat8
+  #Not used on Arch
+  manager_pkg:
+MacOS:
+  {% set darwin_javahome = salt['cmd.run']('/usr/libexec/java_home') if grains.os =='MacOS' else {} %}
+  service: homebrew.mxcl.tomcat
+  ver: 8
+  pkg: tomcat
+  native_pkg: tomcat-native
+  conf_dir: /usr/local/opt/tomcat/libexec/conf
+  main_config: /usr/local/opt/tomcat/libexec/bin/setenv.sh
+  main_config_template: salt://tomcat/files/tomcat-default-CentOS.template
+  limits_prefix: /Library/LaunchAgents/maxfiles.plist
+  java_home: {{ darwin_javahome }}
+  jvm_tmp: /usr/local/opt/tomcat/libexec/temp
+  catalina_base: /usr/local/opt/tomcat/libexec
+  catalina_home: /usr/local/opt/tomcat/libexec
+  catalina_tmpdir: /usr/local/opt/tomcat/libexec/temp
+
+  #Not used on Darwin
+  manager_pkg:
+  user: nobody
+  group: nobody
+  with_haveged: false
+  haveged_enabled: false
+
+  #Not verified on Darwin
+  cluster:
+    simple: false


### PR DESCRIPTION
The purpose of this pull request is to consolidate *some* formula defaults across defaults.yaml, osmap.yaml and pillar.example files in the formula and add MacOS support to osmapping.  

The following are addressed by the PR.

1. pillar.example defines "override" values missing elsewhere in formula (i.e. defaults.yaml), going against good practice of reserving pillars for overrides.  This PR moves *some* to defaults.yaml because formula relies too heavily on pillars for some states.
   - Moved the `pillar.example.tomcat.Catalina_xxxx` variables to defaults.yaml
   - Moved `jvm_tmp`
   - Few others (see diff).

2. pillar.example defines some dummy values which corrupt / fail the installation if naively reused.
     - Section `tomcat.java_opts` has dummy path.
     - Pillar`tomcat.connectors.keystore` has dummy keystore path but SSLEnabled: True (?)
     - Pillar ID "path#to#context" is dummy path which is hard to understand.

3. Some bugs or deficits exist today-
     - Both `pillar.example.tomcat.sites.id` ID need improvement (still wrong/issues).
     - One `pillar.example.tomcat.sites.host_parameter` ID is missing (corruption).
     - We must include `tomcat.Arch.manager_pkg: ` in osmap.yaml for Arch.

4. The osmapping for '`MacOS`' must be defined to support future PR for Darwin/MacOS.

Verified on following (Salt 2017 mostly, Suse has Salt 2016).

[tomcat_on_Darwin_verified (1).txt](https://github.com/saltstack-formulas/tomcat-formula/files/1357620/tomcat_on_Darwin_verified.1.txt)
[manjaro_tomcat_result.log.txt](https://github.com/saltstack-formulas/tomcat-formula/files/1357614/manjaro_tomcat_result.log.txt)
[ubuntu_tomcat_results.log.txt](https://github.com/saltstack-formulas/tomcat-formula/files/1357615/ubuntu_tomcat_results.log.txt)
[suse_tomcat_resultt.log.txt](https://github.com/saltstack-formulas/tomcat-formula/files/1357616/suse_tomcat_resultt.log.txt)
[centos7_tomcat_result.log.txt](https://github.com/saltstack-formulas/tomcat-formula/files/1357617/centos7_tomcat_result.log.txt)
