### PR TITLE
Add MacOS support for tomcat.manage.state

### DIFF
--- a/tomcat/manager.sls
+++ b/tomcat/manager.sls
@@ -5,8 +5,8 @@ include:
 
 {% if grains.os != 'FreeBSD' %}
 
-# on archlinux tomcat manager is already in tomcat package
-{% if grains.os != 'Arch' %}
+# on archlinux/MacOS family tomcat manager is already in tomcat package
+{% if grains.os_family not in ('Arch','MacOS') %}
 {{ tomcat.manager_pkg }}:
   pkg.installed:
     - require:


### PR DESCRIPTION
This PR introduces MacOS support for the tomcat.manage state.  Today this state fails because there is no `manager_pkg` candidate for Homebrew tomcat.

Verified on following (Salt 2017 mostly, Suse has Salt 2016).

[tomcat_on_Darwin_verified (1).txt](https://github.com/saltstack-formulas/tomcat-formula/files/1357620/tomcat_on_Darwin_verified.1.txt)
[manjaro_tomcat_result.log.txt](https://github.com/saltstack-formulas/tomcat-formula/files/1357614/manjaro_tomcat_result.log.txt)
[ubuntu_tomcat_results.log.txt](https://github.com/saltstack-formulas/tomcat-formula/files/1357615/ubuntu_tomcat_results.log.txt)
[suse_tomcat_resultt.log.txt](https://github.com/saltstack-formulas/tomcat-formula/files/1357616/suse_tomcat_resultt.log.txt)
[centos7_tomcat_result.log.txt](https://github.com/saltstack-formulas/tomcat-formula/files/1357617/centos7_tomcat_result.log.txt)