### PR TITLE
Enhance tomcat.cluster state for MacOS

### DIFF
--- a/tomcat/cluster.sls
+++ b/tomcat/cluster.sls
@@ -3,6 +3,7 @@
 include:
   - tomcat.config
 
+{% if grains.os != 'MacOS' %}
 600_server_xml:
   file.accumulated:
     - filename: {{ tomcat.conf_dir }}/server.xml
@@ -11,3 +12,4 @@ include:
     {% endif %}
     - require_in:
       - file: server_xml
+{% endif %}


### PR DESCRIPTION
The tomcat.cluster.600_server_xml state fails on MacOS.  This PR excludes this state on MacOS.

Verified on following (Salt 2017 mostly, Suse has Salt 2016).

[tomcat_on_Darwin_verified (1).txt](https://github.com/saltstack-formulas/tomcat-formula/files/1357620/tomcat_on_Darwin_verified.1.txt)
[manjaro_tomcat_result.log.txt](https://github.com/saltstack-formulas/tomcat-formula/files/1357614/manjaro_tomcat_result.log.txt)
[ubuntu_tomcat_results.log.txt](https://github.com/saltstack-formulas/tomcat-formula/files/1357615/ubuntu_tomcat_results.log.txt)
[suse_tomcat_resultt.log.txt](https://github.com/saltstack-formulas/tomcat-formula/files/1357616/suse_tomcat_resultt.log.txt)
[centos7_tomcat_result.log.txt](https://github.com/saltstack-formulas/tomcat-formula/files/1357617/centos7_tomcat_result.log.txt)