### PR TITLE
Enhance tomcat.config state with MacOS support

### DIFF
--- a/tomcat/files/limit.maxfiles.plist
+++ b/tomcat/files/limit.maxfiles.plist
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>  
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"  
+        "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">  
+  <dict>
+    <key>Label</key>
+    <string>limit.maxfiles</string>
+    <key>ProgramArguments</key>
+    <array>
+      <string>launchctl</string>
+      <string>limit</string>
+      <string>maxfiles</string>
+      <string>{{ soft_limit }}</string>
+      <string>{{ hard_limit }}</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>ServiceIPC</key>
+    <false/>
+  </dict>
+</plist> 


### PR DESCRIPTION
This pull request is an enhancement for the tomcat.config state, introducing full MacOS support.

Verified on following (Salt 2017 mostly, Suse has Salt 2016).

[tomcat_on_Darwin_verified (1).txt](https://github.com/saltstack-formulas/tomcat-formula/files/1357620/tomcat_on_Darwin_verified.1.txt)
[manjaro_tomcat_result.log.txt](https://github.com/saltstack-formulas/tomcat-formula/files/1357614/manjaro_tomcat_result.log.txt)
[ubuntu_tomcat_results.log.txt](https://github.com/saltstack-formulas/tomcat-formula/files/1357615/ubuntu_tomcat_results.log.txt)
[suse_tomcat_resultt.log.txt](https://github.com/saltstack-formulas/tomcat-formula/files/1357616/suse_tomcat_resultt.log.txt)
[centos7_tomcat_result.log.txt](https://github.com/saltstack-formulas/tomcat-formula/files/1357617/centos7_tomcat_result.log.txt)