### PR TITLE
Enhance tomcat state, Add MacOS & launchd support

### DIFF
--- a/tomcat/init.sls
+++ b/tomcat/init.sls
@@ -8,13 +8,23 @@ tomcat:
     {% if tomcat.version is defined %}
     - version: {{ tomcat.version }}
     {% endif %}
+  {%- if grains.os == 'MacOS' %}
+   #Register as Launchd LaunchAgent for users
+    - require_in: tomcat.file.managed
+  file.managed:
+    - name: /Library/LaunchAgents/{{ tomcat.service }}.plist
+    - source: /usr/local/opt/tomcat/{{ tomcat.service }}.plist
+    - group: wheel
+    - require_in: tomcat.cmd.run
+  {% endif %}
   service.running:
     - name: {{ tomcat.service }}
     - enable: {{ tomcat.service_enabled }}
     - watch:
       - pkg: tomcat
 # To install haveged in centos you need the EPEL repository
-{% if tomcat.with_haveged %}
+# There is no haveged in MacOS
+{% if tomcat.with_haveged and grains.os != 'MacOS' %}
   require:
     - pkg: haveged
 


### PR DESCRIPTION
This pull request enhances the tomcat.init state to introduce full MacOS support for Tomcat package from Homebrew (and tap/homebrew-services) solutions.  Integration with Launchd is introduced.

Verified on following (Salt 2017 mostly, Suse has Salt 2016).

[tomcat_on_Darwin_verified (1).txt](https://github.com/saltstack-formulas/tomcat-formula/files/1357620/tomcat_on_Darwin_verified.1.txt)
[manjaro_tomcat_result.log.txt](https://github.com/saltstack-formulas/tomcat-formula/files/1357614/manjaro_tomcat_result.log.txt)
[ubuntu_tomcat_results.log.txt](https://github.com/saltstack-formulas/tomcat-formula/files/1357615/ubuntu_tomcat_results.log.txt)
[suse_tomcat_resultt.log.txt](https://github.com/saltstack-formulas/tomcat-formula/files/1357616/suse_tomcat_resultt.log.txt)
[centos7_tomcat_result.log.txt](https://github.com/saltstack-formulas/tomcat-formula/files/1357617/centos7_tomcat_result.log.txt)