### PR TITLE
Fix tomcat.config state on Suse

### DIFF
--- a/tomcat/osmap.yaml
+++ b/tomcat/osmap.yaml
@@ -23,10 +23,12 @@ CentOS:
   manager_pkg: tomcat-admin-webapps
   main_config_template: salt://tomcat/files/tomcat-default-CentOS.template
 openSUSE:
+  ver: 8
   native_pkg: libtcnative-1-0
   manager_pkg: tomcat-admin-webapps
   main_config_template: salt://tomcat/files/tomcat-default-CentOS.template
 Suse:
+  ver: 8
   native_pkg: libtcnative-1-0
   manager_pkg: tomcat-admin-webapps
   main_config_template: salt://tomcat/files/tomcat-default-CentOS.template


### PR DESCRIPTION
This pull request sets 'ver: 8' for Suse family in osmap.yaml to resolve issue #78 