### PR TITLE
Minor Jinja cleanup - Use unless/onlyif where possible

### DIFF
--- a/tomcat/cluster.sls
+++ b/tomcat/cluster.sls
@@ -3,7 +3,6 @@
 include:
   - tomcat.config
 
-{% if grains.os != 'MacOS' %}
 600_server_xml:
   file.accumulated:
     - filename: {{ tomcat.conf_dir }}/server.xml
@@ -12,4 +11,4 @@ include:
     {% endif %}
     - require_in:
       - file: server_xml
-{% endif %}
+    - unless: test "`uname`" = "Darwin"

--- a/tomcat/config.sls
+++ b/tomcat/config.sls
@@ -16,6 +16,7 @@ tomcat_conf:
   file.managed:
     - name: {{ tomcat.main_config }}
     - source: {{ tomcat.main_config_template }}
+    - makedirs: True
     - template: jinja
     - defaults:
         tomcat: {{ tomcat }}
@@ -43,14 +44,13 @@ tomcat_conf:
 
 # Jasper Listener deprecated in tomcat >= 8
 # https://tomcat.apache.org/tomcat-8.0-doc/changelog.html
-{% if tomcat.ver < 8 %}
 400_server_xml:
   file.accumulated:
     - filename: {{ tomcat.conf_dir }}/server.xml
     - text: enabled
     - require_in:
       - file: server_xml
-{% endif %}
+    - onlyif: test {{ tomcat.ver }} -lt 8
 
 server_xml:
   file.managed:
@@ -68,7 +68,6 @@ server_xml:
     - watch_in:
       - service: tomcat
 
-{% if grains.os != 'FreeBSD' %}
 limits_conf:
   {% if grains.os == 'Arch' %}
   file.append:
@@ -98,5 +97,5 @@ limits_conf:
       - service: tomcat
     - watch_in:
       - service: tomcat
-{% endif %}
+    - unless: test "`uname`" = "FreeBSD"
 

--- a/tomcat/manager.sls
+++ b/tomcat/manager.sls
@@ -3,8 +3,6 @@
 include:
   - tomcat
 
-{% if grains.os != 'FreeBSD' %}
-
 # on archlinux/MacOS family tomcat manager is already in tomcat package
 {% if grains.os_family not in ('Arch','MacOS') %}
 {{ tomcat.manager_pkg }}:
@@ -28,5 +26,5 @@ include:
       - service: tomcat
     - watch_in:
       - service: tomcat
-{% endif %}
+    - unless: test "`uname`" = "FreeBSD"
 


### PR DESCRIPTION
This PR uses `unless` and `onlyif` instead of Jinja for few states as good practice.

The requisite check is primitive syntax for shell portability (sh/ksh/bash/zsh/etc).


```
[INFO    ] Executing state file.managed for [/Library/LaunchDaemons/limit.maxfiles.plist]
[DEBUG   ] Could not LazyLoad file.mod_run_check: 'file.mod_run_check' is not available.
[INFO    ] Executing command 'test "`uname`" = "FreeBSD"' in directory '/Users/xxxxx'
[DEBUG   ] output: 
[DEBUG   ] Last command return code: 1

[INFO    ] Executing state file.managed for [/usr/local/opt/tomcat/libexec/conf/tomcat-users.xml]
[DEBUG   ] Could not LazyLoad file.mod_run_check: 'file.mod_run_check' is not available.
[INFO    ] Executing command 'test "`uname`" = "FreeBSD"' in directory '/Users/xxxxx'
[DEBUG   ] output: 
[DEBUG   ] Last command return code: 1

[INFO    ] Executing state file.accumulated for [600_server_xml]
[DEBUG   ] Could not LazyLoad file.mod_run_check: 'file.mod_run_check' is not available.
[INFO    ] Executing command 'test "`uname`" = "Darwin"' in directory '/Users/xxxxx'
[DEBUG   ] output:
[DEBUG   ] Last command return code: 0
```