### PR TITLE
Fix YAML parse errors due to broken dictionary serialization

### DIFF
--- a/tomcat/config.sls
+++ b/tomcat/config.sls
@@ -19,7 +19,7 @@ tomcat_conf:
     - makedirs: True
     - template: jinja
     - defaults:
-        tomcat: {{ tomcat }}
+        tomcat: {{ tomcat|yaml }}
   {% endif %}
     - require:
       - pkg: tomcat

--- a/tomcat/context.sls
+++ b/tomcat/context.sls
@@ -39,7 +39,7 @@ include:
     - mode: '640'
     - template: jinja
     - defaults:
-      context_elements: {{ tomcat.get('context', {}) }}
+      context_elements: {{ tomcat.get('context', {})|yaml }}
       context_params: {}
     - require:
       - pkg: tomcat
@@ -76,8 +76,8 @@ include:
     - mode: '640'
     - template: jinja
     - defaults:
-      context_elements: {{ data.get('elements', {}) }}
-      context_params: {{ data.get('params', {}) }}
+      context_elements: {{ data.get('elements', {})|yaml }}
+      context_params: {{ data.get('params', {})|yaml }}
     - require:
       - pkg: tomcat
       - file: {{ tomcat.conf_dir }}/Catalina/localhost

--- a/tomcat/manager.sls
+++ b/tomcat/manager.sls
@@ -19,7 +19,7 @@ include:
     - mode: '640'
     - template: jinja
     - defaults:
-      tomcat: {{ tomcat }}
+      tomcat: {{ tomcat|yaml }}
     - require:
       - pkg: tomcat
     - require_in:


### PR DESCRIPTION
This takes a conservative approach to implementing the changes I recommended in #89: I have only patched instances where I know the data structures being rendered are dictionary types.

Note that I am personally unable to test the changes to `context.sls` or `manager.sls`.