### PR TITLE
Fix state failure(s) macOS

### DIFF
--- a/tomcat/init.sls
+++ b/tomcat/init.sls
@@ -11,6 +11,9 @@ tomcat:
   {%- if grains.os == 'MacOS' %}
    #Register as Launchd LaunchAgent for users
     - require_in: tomcat.file.managed
+  cmd.run:
+    - name: brew unlink tomcat && brew link tomcat
+    - unless: test -f /usr/local/opt/tomcat/{{ tomcat.service }}.plist
   file.managed:
     - name: /Library/LaunchAgents/{{ tomcat.service }}.plist
     - source: /usr/local/opt/tomcat/{{ tomcat.service }}.plist


### PR DESCRIPTION
This PR attempts to fix tomcat state failures on MacOS. 

After completion of the `pkg.installed` state (`brew install`) a required service file is missing.
```
          ID: tomcat
    Function: file.managed
        Name: /Library/LaunchAgents/homebrew.mxcl.tomcat.plist
      Result: False
     Comment: Local file source /usr/local/opt/tomcat/homebrew.mxcl.tomcat.plist does not exist
```
Manual troubleshooting gave a solution which this commit automates. 
```
$ brew install tomcat
Warning: tomcat 9.0.11 is already installed, it's just not linked
You can use `brew link tomcat` to link this version.
Error: /usr/local/opt/tomcat is not a valid keg


mac~ messi$ brew link tomcat
Linking /usr/local/Cellar/tomcat/9.0.11... Error: Directory not empty @ dir_s_rmdir - /usr/local/opt/tomcat

$ cd /usr/local/opt/ && mv tomcat tomcat_old

$ brew install tomcat
Warning: tomcat 9.0.11 is already installed, it's just not linked
You can use `brew link tomcat` to link this version.

$ brew link tomcat
Linking /usr/local/Cellar/tomcat/9.0.11... 1 symlinks created
$ sudo ls -l /usr/local/opt/tomcat/ | grep plist
-rw-r--r--   1 messi  admin    471 28 Aug 18:22 homebrew.mxcl.tomcat.plist
```