### PR TITLE
Stop TravisCI spawning >40 CI jobs

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -9,11 +9,8 @@ driver:
   # name: inspec
 
 platforms:
-  - name: ubuntu-14.04
-  - name: ubuntu-16.04
-  - name: debian-7
-  - name: debian-8
-  - name: centos-6
+  - name: ubuntu-18.04
+  - name: debian-9
   - name: centos-7
 
 provisioner:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,47 +9,21 @@ services:
 
 env:
   matrix:
-  - INSTANCE: install-ubuntu-1404
-  - INSTANCE: install-ubuntu-1604
-  - INSTANCE: install-debian-7   
-  - INSTANCE: install-debian-8   
-  - INSTANCE: install-centos-6   
+  - INSTANCE: install-ubuntu-1804
   - INSTANCE: install-centos-7   
-  - INSTANCE: config-ubuntu-1404 
-  - INSTANCE: config-ubuntu-1604 
-  - INSTANCE: config-debian-7    
-  - INSTANCE: config-debian-8    
-  - INSTANCE: config-centos-6    
+  - INSTANCE: install-debian-9
+  - INSTANCE: config-ubuntu-1804 
   - INSTANCE: config-centos-7    
-  - INSTANCE: native-ubuntu-1404 
-  - INSTANCE: native-ubuntu-1604 
-  - INSTANCE: native-debian-7    
-  - INSTANCE: native-debian-8    
-  - INSTANCE: native-centos-6    
+  - INSTANCE: config-debian-9
+  - INSTANCE: native-ubuntu-1804 
   - INSTANCE: native-centos-7    
-  - INSTANCE: manager-ubuntu-1404
-  - INSTANCE: manager-ubuntu-1604
-  - INSTANCE: manager-debian-7   
-  - INSTANCE: manager-debian-8   
-  - INSTANCE: manager-centos-6   
+  - INSTANCE: manager-ubuntu-1804
   - INSTANCE: manager-centos-7   
-  - INSTANCE: expires-ubuntu-1404
-  - INSTANCE: expires-ubuntu-1604
-  - INSTANCE: expires-debian-7   
-  - INSTANCE: expires-debian-8   
-  - INSTANCE: expires-centos-6   
+  - INSTANCE: expires-ubuntu-1804
   - INSTANCE: expires-centos-7   
-  - INSTANCE: context-ubuntu-1404
-  - INSTANCE: context-ubuntu-1604
-  - INSTANCE: context-debian-7   
-  - INSTANCE: context-debian-8   
-  - INSTANCE: context-centos-6   
+  - INSTANCE: context-ubuntu-1804
   - INSTANCE: context-centos-7   
-  - INSTANCE: cluster-ubuntu-1404
-  - INSTANCE: cluster-ubuntu-1604
-  - INSTANCE: cluster-debian-7   
-  - INSTANCE: cluster-debian-8   
-  - INSTANCE: cluster-centos-6   
+  - INSTANCE: cluster-ubuntu-1804
   - INSTANCE: cluster-centos-7
 
 # https://github.com/zuazo/kitchen-in-travis-native/issues/1#issuecomment-142455888


### PR DESCRIPTION
This PR greatly reduces the number of Travis CI jobs spawned:  from 42 to ~10 CI Jobs).  Nobody has time to check all the failing jobs.  Even 10 jobs is too much for busy community.
