### PR TITLE
Fix iteritems

### DIFF
--- a/tomcat/context.sls
+++ b/tomcat/context.sls
@@ -8,8 +8,8 @@ include:
 #Tomcat fails if pillar-defined webapps are not deployed yet.
 #Create the missing 'appBase' directories so Tomcat works!
 
-    {% for id, data in tomcat.get('sites', {}).iteritems() %}
-      {% for k, v in data.iteritems() %}
+    {% for id, data in tomcat.get('sites', {}).items() %}
+      {% for k, v in data.items() %}
         {% if k == 'appBase' %}
 {{ tomcat.catalina_home }}/webapps/{{ data['appBase'] }}:
   file.directory:

--- a/tomcat/files/context.xml
+++ b/tomcat/files/context.xml
@@ -36,10 +36,10 @@
     <WatchedResource>WEB-INF/web.xml</WatchedResource>
     <WatchedResource>${catalina.base}/conf/web.xml</WatchedResource>
 
-{% for element_type, elements in context_elements.iteritems() -%}
-  {% for element, params in elements.iteritems() -%}
+{% for element_type, elements in context_elements.items() -%}
+  {% for element, params in elements.items() -%}
     <{{ element_type }}
-            {%- for k, v in params.iteritems() %}
+            {%- for k, v in params.items() %}
             {{ k }}="{{ v }}"
             {%- endfor %}
     />

--- a/tomcat/files/server.xml
+++ b/tomcat/files/server.xml
@@ -56,9 +56,9 @@
   -->
   <GlobalNamingResources>
     {% if resources -%}
-    {% for id, params in resources.iteritems() -%}
+    {% for id, params in resources.items() -%}
     <Resource
-    {% for k, v in params.iteritems() %}
+    {% for k, v in params.items() %}
               {{ k }}="{{ v }}"
     {%- endfor %}
     />
@@ -82,9 +82,9 @@
    -->
   <Service name="Catalina">
     {% if connectors -%}
-    {% for id, params in connectors.iteritems() -%}
+    {% for id, params in connectors.items() -%}
     <Connector
-    {% for k, v in params.iteritems() %}
+    {% for k, v in params.items() %}
                {{ k }}="{{ v }}"
     {%- endfor %}
     />
@@ -141,10 +141,10 @@
       </Realm>
 
       {% if sites %}
-      {% for id, site in sites.iteritems() %}
+      {% for id, site in sites.items() %}
       {%- set host_name = site.name if site.name is defined else id %}
       <Host name="{{ host_name }}"
-          {%- for k, v in site.host_parameters.iteritems()  %}
+          {%- for k, v in site.host_parameters.items()  %}
             {{ k }}="{{ v }}"
           {%- endfor %}>
             {%- if (site.path is defined and site.docBase is defined) %}
@@ -161,7 +161,7 @@
             {%- if site.valves is defined %}
 	    {%- for valve in site.valves  %}
               <Valve
-              {%- for k, v in valve.iteritems() %}
+              {%- for k, v in valve.items() %}
                 {{ k }}="{{ v }}"
               {%- endfor %} />
 	    {%- endfor %}

--- a/tomcat/files/tomcat-users.xml
+++ b/tomcat/files/tomcat-users.xml
@@ -13,7 +13,7 @@
 {% for role in salt['pillar.get']('tomcat:manager:roles', {}) %}
     <role rolename="{{ role }}" />
 {% endfor %}
-{% for user, userconfig in salt['pillar.get']('tomcat:manager:users', {}).iteritems() %}
+{% for user, userconfig in salt['pillar.get']('tomcat:manager:users', {}).items() %}
     <user username="{{ user }}" password="{{ userconfig['passwd'] }}" roles="{{ userconfig['roles'] }}"/>
 {% endfor %}
 </tomcat-users>


### PR DESCRIPTION
Fix for MacOS (py 2.7.10).

`base:tomcat:context failed: Jinja variable 'dict object' has no attribute 'iteritems'.`