### PR TITLE
Tomcat users

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -97,7 +97,12 @@ tomcat:
             roles: manager-gui,manager-script,manager-jmx,manager-status
           saltuser2:
             passwd: RfgpE2iQwD
-            roles: manager-gui,manager-script,manager-jmx,manager-status
+            # Alternatively, roles can also be a list
+            roles:
+              - manager-gui
+              - manager-script
+              - manager-jmx
+              - manager-status
     context:
       # Let's you define multiple elements in the global context.xml file.
       # The state does not try to be clever about the correctness of what you add here,

--- a/tomcat/files/tomcat-users.xml
+++ b/tomcat/files/tomcat-users.xml
@@ -9,11 +9,12 @@
 
 -->
 <tomcat-users>
-
-{% for role in salt['pillar.get']('tomcat:manager:roles', {}) %}
+{# Roles #}
+{%- for role in salt['pillar.get']('tomcat:manager:roles', {}) %}
     <role rolename="{{ role }}" />
-{% endfor %}
-{% for user, userconfig in salt['pillar.get']('tomcat:manager:users', {}).items() %}
+{%- endfor %}
+{# Users #}
+{%- for user, userconfig in salt['pillar.get']('tomcat:manager:users', {}).items() %}
     <user username="{{ user }}" password="{{ userconfig['passwd'] }}" roles="{{ userconfig['roles'] }}"/>
-{% endfor %}
+{%- endfor %}
 </tomcat-users>

--- a/tomcat/files/tomcat-users.xml
+++ b/tomcat/files/tomcat-users.xml
@@ -1,3 +1,10 @@
+{%- macro comma_list(roles) %}
+{%-  if roles is iterable and roles is not string %}
+     {{- ','.join(roles) }}
+{%- else %}
+     {{- roles }}
+{%- endif %}
+{%- endmacro -%}
 <?xml version='1.0' encoding='utf-8'?>
 <!--
 
@@ -15,6 +22,6 @@
 {%- endfor %}
 {# Users #}
 {%- for user, userconfig in salt['pillar.get']('tomcat:manager:users', {}).items() %}
-    <user username="{{ user }}" password="{{ userconfig['passwd'] }}" roles="{{ userconfig['roles'] }}"/>
+    <user username="{{ user }}" password="{{ userconfig['passwd'] }}" roles="{{ comma_list(userconfig['roles']) }}"/>
 {%- endfor %}
 </tomcat-users>


### PR DESCRIPTION
* Remove empty lines in generated files, between `roles`, and between `users`
* Allow `roles` to be a list