### PR TITLE
chore(version): use tomcat9 on ubuntu/debian

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -3,7 +3,7 @@
 ---
 tomcat:
   # The Tomcat version can be overridden like so.
-  # ver: 7
+  # ver: 9
   security: 'no'
   # The Java home directory can be overridden like so.
   # java_home: '/usr/lib/jvm/default-java'

--- a/tomcat/clean.sls
+++ b/tomcat/clean.sls
@@ -6,11 +6,27 @@ tomcat stop services and clean packages:
       - {{ tomcat.service }}
       - haveged
     - unless: {{ grains.os == 'MacOS' and tomcat.ver|int < 9 }}   ####no macOS plist file for tomcat9
+  pkg.purged:
+    - names:
+      - {{ tomcat.manager_pkg }}
+      - {{ tomcat.native_pkg }}
+      - {{ tomcat.common_pkg }}
+      - libtomcat{{ tomcat.ver }}
+      - libtomcat{{ tomcat.ver }}-java
+      - {{ tomcat.pkg }}
+      - haveged
   file.absent:
     - names:
       - /usr/local/opt/tomcat
-  pkg.removed:
-    - names:
-      - {{ tomcat.native_pkg }}
-      - {{ tomcat.pkg }}
-      - haveged
+      - /usr/local/opt/tomcat{{ tomcat.ver }}
+      - /usr/local/opt/tomcat{{ tomcat.ver }}-admin
+      - /usr/local/opt/tomcat{{ tomcat.ver }}-common
+      - /usr/local/opt/tomcat{{ tomcat.ver|int -1 }}
+      - /usr/local/opt/tomcat{{ tomcat.ver|int -1 }}-admin
+      - /usr/local/opt/tomcat{{ tomcat.ver|int -1 }}-common
+      - /usr/share/tomcat{{ tomcat.ver }}
+      - /usr/share/tomcat{{ tomcat.ver }}-admin
+      - /usr/share/tomcat{{ tomcat.ver }}-common
+      - /usr/share/tomcat{{ tomcat.ver|int -1 }}
+      - /usr/share/tomcat{{ tomcat.ver|int -1 }}-admin
+      - /usr/share/tomcat{{ tomcat.ver|int -1 }}-common

--- a/tomcat/defaults.yaml
+++ b/tomcat/defaults.yaml
@@ -3,6 +3,8 @@
 ---
 tomcat:
   pkg: tomcat
+  manager_pkg: tomcat-admin
+  common_pkg: tomcat-common
   ver: 7
   with_haveged: false
   haveged_enabled: false

--- a/tomcat/osfamilymap.yaml
+++ b/tomcat/osfamilymap.yaml
@@ -2,23 +2,24 @@
 # vim: ft=yaml
 ---
 Debian:
-  ver: 8
-  pkg: tomcat8
+  ver: 9
+  pkg: tomcat9
   native_pkg: libtcnative-1
-  manager_pkg: tomcat8-admin
+  manager_pkg: tomcat9-admin
+  common_pkg: tomcat9-common
   with_haveged: true
   haveged_enabled: true
-  conf_dir: /etc/tomcat8
-  main_config: /etc/default/tomcat8
+  conf_dir: /etc/tomcat9
+  main_config: /etc/default/tomcat9
   main_config_template: salt://tomcat/files/tomcat-default-Debian.template
-  service: tomcat8
-  user: tomcat8
-  group: tomcat8
+  service: tomcat9
+  user: tomcat
+  group: tomcat
   java_home: /usr/lib/jvm/default-java
-  catalina_base: /var/lib/tomcat8
-  catalina_home: /usr/share/tomcat8
-  catalina_pid: /var/run/tomcat8.pid
-  catalina_tmpdir: /var/cache/tomcat8/temp
+  catalina_base: /var/lib/tomcat9
+  catalina_home: /usr/share/tomcat9
+  catalina_pid: /var/run/tomcat.pid
+  catalina_tmpdir: /var/cache/tomcat/temp
 
 RedHat:
   native_pkg: tomcat-native


### PR DESCRIPTION

### PR progress checklist (to be filled in by reviewers)
<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [x] Changes to documentation are appropriate (or tick if not required)
- [x] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?
<!-- Please tick each box that is relevant (after creating the PR). -->

#### Primary type
<!-- There really should be only *one* of these types ticked for each PR. -->

- [ ] `[build]`    Changes related to the build system
- [x] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [ ] `[ci]`       Changes to the continuous integration configuration
- [ ] `[feat]`     A new feature
- [x] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [ ] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type
<!-- Most PRs should include all of the following types as well. -->

- [ ] `[docs]`     Documentation changes
- [ ] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?
<!-- If so, change the following to a `Yes` and explain what the breaking changes are. -->
<!-- If there are multiple breaking changes, list them all. -->

No.

### Related issues and/or pull requests
<!-- Please link any related issues/PRs here, especially any issues that are closed by this PR. -->

#97 

### Describe the changes you're proposing
<!-- A clear and concise description of what you have implemented. -->
<!-- Consider explaining each commit if they cover different aspects of the proposed changes. -->

Since #97 was never fixed the best solution is to use Tomcat9 on the Debian family and close #97

### Pillar / config required to test the proposed changes
<!-- Provide links to the SLS files and/or relevant configs (be sure to remove sensitive info). -->



### Debug log showing how the proposed changes work
<!-- Include a debug log showing how these changes work, e.g. using `salt-minion -l debug`. -->
<!-- Alternatively, linking to Kitchen debug logs is useful, e.g. via. Travis CI. -->
<!-- Most useful is providing a passing InSpec test, which can be used to verify any proposed changes. -->



### Documentation checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Updated the `README` (e.g. `Available states`).
- [ ] Updated `pillar.example`.

### Testing checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Included in Kitchen (i.e. under `state_top`).
- [ ] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [ ] Updated the relevant test pillar.

### Additional context
<!-- Add any other context about the proposed changes here. -->
```
          ID: tomcat package installed and service running
    Function: service.running
        Name: tomcat9
      Result: True
     Comment: Service tomcat9 is already enabled, and is running
     Started: 21:52:26.118312
    Duration: 1428.815 ms
     Changes:
              ----------
              tomcat9:
                  True

Summary for local
-------------
Succeeded: 11 (changed=6)
Failed:     0
-------------
Total states run:     11
Total run time:   26.494 s
vagrant@ubuntu1804:~$ systemctl status tomcat9
● tomcat9.service - Apache Tomcat 9 Web Application Server
   Loaded: loaded (/lib/systemd/system/tomcat9.service; enabled; vendor preset: enabled)
   Active: active (running) since Thu 2020-11-26 21:52:27 UTC; 12s ago
     Docs: https://tomcat.apache.org/tomcat-9.0-doc/index.html
  Process: 12505 ExecStartPre=/usr/libexec/tomcat9/tomcat-update-policy.sh (code=exited, status=0/SUCCESS)
 Main PID: 12518 (java)
    Tasks: 36 (limit: 4915)
   CGroup: /system.slice/tomcat9.service
           └─12518 /usr/lib/jvm/java-11-openjdk-amd64/bin/java -Djava.util.logging.config.file=/var/lib/tomcat9/conf/logging.properties -Djava.util.logging.ma

Nov 26 21:52:30 ubuntu1804.localdomain tomcat9[12518]: Deployment of deployment descriptor [/etc/tomcat9/Catalina/localhost/manager.xml] has finished in [1,17
Nov 26 21:52:30 ubuntu1804.localdomain tomcat9[12518]: Deploying deployment descriptor [/etc/tomcat9/Catalina/localhost/host-manager.xml]
Nov 26 21:52:30 ubuntu1804.localdomain tomcat9[12518]: The path attribute with value [/host-manager] in deployment descriptor [/etc/tomcat9/Catalina/localhost
Nov 26 21:52:30 ubuntu1804.localdomain tomcat9[12518]: At least one JAR was scanned for TLDs yet contained no TLDs. Enable debug logging for this logger for a
Nov 26 21:52:30 ubuntu1804.localdomain tomcat9[12518]: Deployment of deployment descriptor [/etc/tomcat9/Catalina/localhost/host-manager.xml] has finished in
Nov 26 21:52:30 ubuntu1804.localdomain tomcat9[12518]: Deploying web application directory [/var/lib/tomcat9/webapps/ROOT]
Nov 26 21:52:31 ubuntu1804.localdomain tomcat9[12518]: At least one JAR was scanned for TLDs yet contained no TLDs. Enable debug logging for this logger for a
Nov 26 21:52:31 ubuntu1804.localdomain tomcat9[12518]: Deployment of web application directory [/var/lib/tomcat9/webapps/ROOT] has finished in [567] ms
Nov 26 21:52:31 ubuntu1804.localdomain tomcat9[12518]: Starting ProtocolHandler ["http-nio-8080"]
Nov 26 21:52:31 ubuntu1804.localdomain tomcat9[12518]: Server startup in [2,362] milliseconds
```

