### PR TITLE
feat: Support for Debian 12

### DIFF
--- a/tomcat/osfamilymap.yaml
+++ b/tomcat/osfamilymap.yaml
@@ -2,24 +2,24 @@
 # vim: ft=yaml
 ---
 Debian:
-  ver: 9
-  pkg: tomcat9
+  ver: 10
+  pkg: tomcat10
   native_pkg: libtcnative-1
-  manager_pkg: tomcat9-admin
-  common_pkg: tomcat9-common
+  manager_pkg: tomcat10-admin
+  common_pkg: tomcat10-common
   with_haveged: true
   haveged_enabled: true
-  conf_dir: /etc/tomcat9
-  main_config: /etc/default/tomcat9
+  conf_dir: /etc/tomcat10
+  main_config: /etc/default/tomcat10
   main_config_template: salt://tomcat/files/tomcat-default-Debian.template
-  service: tomcat9
+  service: tomcat10
   user: tomcat
   group: tomcat
   java_home: /usr/lib/jvm/default-java
-  catalina_base: /var/lib/tomcat9
-  catalina_home: /usr/share/tomcat9
-  catalina_pid: /var/run/tomcat9.pid
-  catalina_tmpdir: /var/cache/tomcat9/temp
+  catalina_base: /var/lib/tomcat10
+  catalina_home: /usr/share/tomcat10
+  catalina_pid: /var/run/tomcat10.pid
+  catalina_tmpdir: /var/cache/tomcat10/temp
 
 RedHat:
   native_pkg: tomcat-native

--- a/tomcat/osfingermap.yaml
+++ b/tomcat/osfingermap.yaml
@@ -2,7 +2,49 @@
 # vim: ft=yaml
 ---
 # os: Debian
-Debian-10: {}
+Debian-12:
+  java_opts:
+    - 'Djava.awt.headless=true'
+    - 'Xmx128m'
+    - 'XX:+UseConcMarkSweepGC'
+Debian-11:
+  ver: 9
+  pkg: tomcat9
+  native_pkg: libtcnative-1
+  manager_pkg: tomcat9-admin
+  common_pkg: tomcat9-common
+  with_haveged: true
+  haveged_enabled: true
+  conf_dir: /etc/tomcat9
+  main_config: /etc/default/tomcat9
+  main_config_template: salt://tomcat/files/tomcat-default-Debian.template
+  service: tomcat9
+  user: tomcat
+  group: tomcat
+  java_home: /usr/lib/jvm/default-java
+  catalina_base: /var/lib/tomcat9
+  catalina_home: /usr/share/tomcat9
+  catalina_pid: /var/run/tomcat9.pid
+  catalina_tmpdir: /var/cache/tomcat9/temp
+Debian-10:
+  ver: 9
+  pkg: tomcat9
+  native_pkg: libtcnative-1
+  manager_pkg: tomcat9-admin
+  common_pkg: tomcat9-common
+  with_haveged: true
+  haveged_enabled: true
+  conf_dir: /etc/tomcat9
+  main_config: /etc/default/tomcat9
+  main_config_template: salt://tomcat/files/tomcat-default-Debian.template
+  service: tomcat9
+  user: tomcat
+  group: tomcat
+  java_home: /usr/lib/jvm/default-java
+  catalina_base: /var/lib/tomcat9
+  catalina_home: /usr/share/tomcat9
+  catalina_pid: /var/run/tomcat9.pid
+  catalina_tmpdir: /var/cache/tomcat9/temp
 Debian-9:
   ver: 8
   pkg: tomcat8


### PR DESCRIPTION
<!--
Please fill in this PR template to make it easier to review and merge.

It has been designed so that a lot of it can be completed *after* submitting it,
e.g. filling in the checklists.

Notes:
1. Please keep the PR as small as is practicable; the larger a PR gets, the harder it becomes to review and the more time it requires to get it merged.
2. Similarly, please avoid PRs that cover more than one type; it should be a _bug fix_ *OR* a _new feature_ *OR* a _refactor_, etc.
3. Please direct questions to the [`#formulas` channel on Slack](https://saltstackcommunity.slack.com/messages/C7LG8SV54/), which is bridged to `#saltstack-formulas` on Freenode.
4. Feel free to suggest improvements to this template by reporting an issue or submitting a PR.  The source of this template is:
  - https://github.com/saltstack-formulas/.github/blob/master/.github/pull_request_template.md
-->

### PR progress checklist (to be filled in by reviewers)
<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [ ] Changes to documentation are appropriate (or tick if not required)
- [ ] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?
<!-- Please tick each box that is relevant (after creating the PR). -->

#### Primary type
<!-- There really should be only *one* of these types ticked for each PR. -->

- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [ ] `[ci]`       Changes to the continuous integration configuration
- [x] `[feat]`     A new feature
- [ ] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [ ] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type
<!-- Most PRs should include all of the following types as well. -->

- [ ] `[docs]`     Documentation changes
- [ ] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?
<!-- If so, change the following to a `Yes` and explain what the breaking changes are. -->
<!-- If there are multiple breaking changes, list them all. -->

No.

### Related issues and/or pull requests
<!-- Please link any related issues/PRs here, especially any issues that are closed by this PR. -->



### Describe the changes you're proposing
<!-- A clear and concise description of what you have implemented. -->
<!-- Consider explaining each commit if they cover different aspects of the proposed changes. -->

Add support for Debian 12.

### Pillar / config required to test the proposed changes
<!-- Provide links to the SLS files and/or relevant configs (be sure to remove sensitive info). -->

The files from the tests, with `no_MaxPermSize.sls` exception.


### Debug log showing how the proposed changes work
<!-- Include a debug log showing how these changes work, e.g. using `salt-minion -l debug`. -->
<!-- Alternatively, linking to Kitchen debug logs is useful, e.g. via. Travis CI. -->
<!-- Most useful is providing a passing InSpec test, which can be used to verify any proposed changes. -->

The Debian 12 saltimages seem broken at the moment, which need work before tests can be added.

[salt.log](https://github.com/saltstack-formulas/tomcat-formula/files/14839038/salt.log)


### Documentation checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Updated the `README` (e.g. `Available states`).
- [ ] Updated `pillar.example`.

### Testing checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Included in Kitchen (i.e. under `state_top`).
- [ ] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [ ] Updated the relevant test pillar.

### Additional context
<!-- Add any other context about the proposed changes here. -->


